### PR TITLE
Fix for undeclared_LC_ALL error

### DIFF
--- a/debian/patches/add-locale-lib.patch
+++ b/debian/patches/add-locale-lib.patch
@@ -1,0 +1,13 @@
+Description:Include <locale.h> in guvcview.c to avoild 
+"undeclared LC_ALL" error when compiling.
+Author: Xiangwei Gui <yuemeng.gui@gail.com>
+--- a/guvcview/guvcview.c
++++ b/guvcview/guvcview.c
+@@ -28,6 +28,7 @@
+ #include <sys/stat.h>
+ #include <sys/resource.h>
+ #include <errno.h>
++#include <locale.h>
+ 
+ #include "gview.h"
+ #include "gviewv4l2core.h"

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 update-manpage
 update-appdata-to-new-format
+add-locale-lib.patch


### PR DESCRIPTION
Trivial fix to avoid "undeclared LC_ALL" error when compiling.